### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,7 @@
     />
 
     <link
-      href="{{ .RSSlink }}"
+      href="{{ .RSSLink }}"
       rel="alternate"
       type="application/rss+xml"
       title="{{ .Site.Title }}"


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.